### PR TITLE
remove credentials when printing paste url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-pbin
-====
+# pbin
 
 CLI tool for [Stikked][1] based pastebin services, like http://paste.mate-desktop.org/
 
@@ -7,7 +6,7 @@ Inspired by [mpaste][2] from [mate-desktop][3], but I did not want to have Pytho
 
 ## Installing
 
-Just copy [pbin.sh](https://raw.githubusercontent.com/glensc/pbin/master/pbin.sh) to somewhere in your `$PATH`:
+Copy [pbin.sh](https://raw.githubusercontent.com/glensc/pbin/master/pbin.sh) to somewhere in your `$PATH`:
 
 ```
 URL=https://raw.githubusercontent.com/glensc/pbin/master/pbin.sh
@@ -23,8 +22,7 @@ chmod +x $PBIN
 
 License: GPL v2
 
-(c) 2014 Elan Ruusamäe <glen@pld-linux.org>
-
+(c) 2014-2018 Elan Ruusamäe <glen@pld-linux.org>
 
   [1]: https://github.com/claudehohl/Stikked
   [2]: https://github.com/mate-desktop/mate-desktop/blob/1.8/tools/mpaste

--- a/pbin.sh
+++ b/pbin.sh
@@ -4,7 +4,7 @@
 # Default server: paste.mate-desktop.org
 # URL: https://github.com/glensc/pbin
 
-# Copyright (C) 2014 Elan Ruusamäe
+# Copyright (C) 2014-2018 Elan Ruusamäe
 
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -26,6 +26,13 @@ PROGRAM=${0##*/}
 # can be overriden from env
 : ${PASTE_URL='http://paste.mate-desktop.org/api/create'}
 #: ${PASTE_APIKEY='apikey'}
+
+# filter url for printing (remove password)
+print_url() {
+	local url="$1"
+
+	echo "$url" | sed -e 's;://[^@]*@;://;'
+}
 
 # paste. take input from stdin
 pastebin() {
@@ -158,7 +165,7 @@ while :; do
 	shift
 done
 
-echo "Paste endpoint: $PASTE_URL"
+printf "Paste endpoint: %s\n" "$(print_url "$PASTE_URL")"
 
 # if we have more commandline arguments, set these as title
 if [ "${title+set}" != "set" ]; then


### PR DESCRIPTION
remove password showing when user has defined paste url:

```
export PASTE_URL='https://user:pass@pastebin.example.net/api/create'
```